### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,8 @@
 name: "build"
 
+permissions:
+  contents: read
+
 on:
   push:
     tags:


### PR DESCRIPTION
Potential fix for [https://github.com/santoshkowshikhr/go-build-deploy/security/code-scanning/1](https://github.com/santoshkowshikhr/go-build-deploy/security/code-scanning/1)

In general, this problem is fixed by explicitly defining a `permissions` block for the workflow or for each job, restricting the `GITHUB_TOKEN` to the minimal scope required (typically `contents: read` for build/lint jobs). This prevents the workflow from inheriting potentially broad read–write defaults from the repository or organization.

For this workflow, the simplest, least disruptive fix is to add a `permissions` block at the workflow (root) level, right after the `name` (or after `on:`), setting `contents: read`. None of the existing steps need write access, so restricting to read will not change behavior. Alternatively, we could add a `permissions` block under `jobs.build`, but a root-level block better enforces least privilege for any future jobs unless they explicitly override it.

Concretely, in `.github/workflows/build.yml`, insert:

```yaml
permissions:
  contents: read
```

near the top of the file, aligned with `name:` and `on:`. No imports or additional definitions are needed; this is purely a YAML configuration change inside the existing workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
